### PR TITLE
Add / format help text

### DIFF
--- a/app/Commands/AddCommand.php
+++ b/app/Commands/AddCommand.php
@@ -27,15 +27,20 @@ class AddCommand extends Command
      */
     protected $description = 'Add a frame that happened in the past to the given project.';
 
+    /**
+     * @var string
+     */
     protected $help = <<<'HELP'
-The start time of the frame must be specified with the --from option.  The start time may be any textual datetime
-format such as '2019-05-01 22:34:46' or a human readable difference such as '2 hours ago'.
+The start time of the frame must be specified with the --from option. The start
+time may be any textual datetime format such as '2019-05-01 22:34:46' or a human
+readable difference such as '2 hours ago'.
 
-You may specify an end time with the --to option.  The --to option accepts all of the same datetime formats as the
---from option.
+You may specify an end time with the --to option. The --to option accepts all of
+the same datetime formats as the --from option.
 
-If you would rather specify an interval than a specific end time you can use the --interval option.  The --interval
-option accepts intervals such as '3h 12m' (meaning 3 hours, 12 minutes in this example).
+If you would rather specify an interval than a specific end time you can use the
+--interval option. The --interval option accepts intervals such as '3h 12m'
+(meaning 3 hours, 12 minutes in this example).
 
 If neither the --to or --interval options are specified the frame will end at the current time.
 HELP;

--- a/app/Commands/ReportCommand.php
+++ b/app/Commands/ReportCommand.php
@@ -27,6 +27,43 @@ class ReportCommand extends Command
      */
     protected $description = 'Report the time spent on the given projects.';
 
+
+    /**
+     * @var string
+     */
+    protected $help = <<<'HELP'
+The start time of the report may be specified with the --from option. The start
+time may be any textual datetime format such as '2019-05-01 22:34:46' or a human
+readable difference such as '2 hours ago'. If the start time is not specified it
+will default to the first of the current month.
+
+You may specify an end time with the --to option. The --to option accepts all of
+the same datetime formats as the --from option.
+
+If you would rather specify an interval than a specific end time you can use the
+--interval option. The --interval option accepts intervals such as '3h 12m'
+(meaning 3 hours, 12 minutes in this example).
+
+If neither the --to or --interval options are specified the end time will
+default to the current time.
+
+The report format may be specified with the --format option. Available options
+are text, CSV, and JSON.
+
+The report can be filtered by tag or project with the --tag and --project
+options.  If not specified frames for all tags and projects are included.
+
+The report is printed to STDOUT. You can pipe the output to create a file, i.e.
+`hours report --format csv > timesheet.csv`.
+HELP;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->setHelp($this->help);
+    }
+
     public function handle(): void
     {
         Report::build()

--- a/app/Commands/SettingsEditCommand.php
+++ b/app/Commands/SettingsEditCommand.php
@@ -16,6 +16,36 @@ class SettingsEditCommand extends Command
     {key : The key to edit}
     {value : The value to set}';
 
+        /**
+     * @var string
+     */
+    protected $help = <<<'HELP'
+The settings:edit command requires two arguments: the name of the setting to
+edit and the value to set it to.
+
+The following settings are supported:
+
+timezone: The timezone to use for input and display. Must be one of the timezones
+supported by PHP.  See https://www.php.net/manual/en/timezones.php for a complete
+list.
+
+date_format: The format string to use for dates.  Defaults to `F j, Y`. See the
+PHP documentation for more info: https://www.php.net/manual/en/function.date.php
+
+date_format: The format string to use for times.  Defaults to `g:i a`. See the
+PHP documentation for more info: https://www.php.net/manual/en/function.date.php
+
+interval_format: The format string to use for intervals.  Defaults to `%h:%I`.
+See the PHP documentation for more info: https://www.php.net/manual/en/dateinterval.format.php
+HELP;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->setHelp($this->help);
+    }
+
     /**
      * @var string
      */

--- a/app/Commands/StartCommand.php
+++ b/app/Commands/StartCommand.php
@@ -24,6 +24,30 @@ class StartCommand extends Command
      */
     protected $description = 'Start tracking time for the given project.';
 
+    /**
+     * @var string
+     */
+    protected $help = <<<'HELP'
+The only required argument is the project name.
+
+You may specify the start time using the --at option. This is useful if you
+forgot to start time tracking. For example, `hours start blog --at '5 minutes ago'`
+would begin a frame 5 minutes ago for the 'blog' project.
+
+Tags may be specified with the --tag option.  If the tag does not exist it will
+be created.
+
+You can attach notes to the frame with the --notes option.  The notes option
+accepts any text that you would like to add to the frame.
+HELP;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->setHelp($this->help);
+    }
+
     public function handle(): void
     {
         if ($active = Frame::active()->first()) {


### PR DESCRIPTION
I ended up only writing help text for the commands that weren't self explanatory or had a lot of options.

Closes #7.