### PR TITLE
Limit interval cascades to hours and minutes

### DIFF
--- a/app/Carbon/CarbonIntervalPresentMixin.php
+++ b/app/Carbon/CarbonIntervalPresentMixin.php
@@ -15,9 +15,20 @@ class CarbonIntervalPresentMixin
     public function presentInterval(): \Closure
     {
         return function (): string {
-            return $this
+            $cascades = CarbonInterval::getCascadeFactors();
+
+            CarbonInterval::setCascadeFactors([
+                'minute' => [60, 'seconds'],
+                'hour' => [60, 'minutes'],
+            ]);
+
+            $interval = $this
                 ->cascade()
                 ->format(Settings::get('interval_format', '%h:%I'));
+
+            CarbonInterval::setCascadeFactors($cascades);
+
+            return $interval;
         };
     }
 }

--- a/tests/Unit/ReportTest.php
+++ b/tests/Unit/ReportTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Frame;
+use App\Report;
+use App\Project;
+use Tests\TestCase;
+use Illuminate\Support\Facades\Date;
+
+class ReportTest extends TestCase
+{
+    public function testTotal()
+    {
+        $project = factory(Project::class)->create(['name' => 'blog']);
+
+        // 8:00
+        factory(Frame::class)->create([
+            'project_id' => $project->id,
+            'started_at' => Date::parse('2019-05-03 9:00 AM'),
+            'stopped_at' => Date::parse('2019-05-03 5:00 PM'),
+        ]);
+
+        // 8:00
+        factory(Frame::class)->create([
+            'project_id' => $project->id,
+            'started_at' => Date::parse('2019-05-04 9:00 AM'),
+            'stopped_at' => Date::parse('2019-05-04 5:00 PM'),
+        ]);
+
+        // 8:15
+        factory(Frame::class)->create([
+            'project_id' => $project->id,
+            'started_at' => Date::parse('2019-05-05 9:00 AM'),
+            'stopped_at' => Date::parse('2019-05-05 5:15 PM'),
+        ]);
+
+        // 00:15
+        factory(Frame::class)->create([
+            'project_id' => $project->id,
+            'started_at' => Date::parse('2019-05-06 9:00 AM'),
+            'stopped_at' => Date::parse('2019-05-06 9:15 AM'),
+        ]);
+
+        // 00:30
+        factory(Frame::class)->create([
+            'project_id' => $project->id,
+            'started_at' => Date::parse('2019-05-06 9:15 AM'),
+            'stopped_at' => Date::parse('2019-05-06 9:45 AM'),
+        ]);
+
+        // 00:45
+        factory(Frame::class)->create([
+            'project_id' => $project->id,
+            'started_at' => Date::parse('2019-05-06 9:45 AM'),
+            'stopped_at' => Date::parse('2019-05-06 10:30 AM'),
+        ]);
+
+        $report = Report::build()
+            ->from(Date::create(2019, 05, 01))
+            ->to(Date::create(2019, 05, 31))
+            ->create();
+
+        $this->assertSame('25:45', $report->total()->presentInterval());
+    }
+}


### PR DESCRIPTION
Since we only display hours and minutes we need to prevent
cascading hours to days, days to weeks, etc.

Without this fix, if you sum three intervals that are 8 hours each the interval would become '1 day 0 hours 0 minutes'. Since the report only shows hours and minutes the total would display '0:00'. We really want the total to display '24:00' instead. The same issue exists when summing minutes that total > 60.

See https://carbon.nesbot.com/docs/#api-interval for more info.