### PR TITLE
Adds #12 default project.

### DIFF
--- a/app/Commands/AddCommand.php
+++ b/app/Commands/AddCommand.php
@@ -19,7 +19,7 @@ class AddCommand extends Command implements CompletionAwareInterface
      * @var string
      */
     protected $signature = 'add
-        {project : The name of the project to add a frame to}
+        {project? : The name of the project to add a frame to}
         {--f|from= : The start time of the frame}
         {--t|to= : the end time of the frame}
         {--i|interval= : An interval for the length of the frame}
@@ -64,8 +64,14 @@ HELP;
             return;
         }
 
+        if (!$project = $this->projectArgument()) {
+            $this->error('No project has been configured, either provide a project or set a default');
+
+            return;
+        }
+
         $frame = Frame::add(
-            $this->argument('project'),
+            $this->projectArgument(),
             $this->dateOption('from'),
             $this->option('interval') ? $this->getInterval() : $this->dateOption('to')
         )->addTags($this->option('tag'))

--- a/app/Commands/AddCommand.php
+++ b/app/Commands/AddCommand.php
@@ -64,7 +64,7 @@ HELP;
             return;
         }
 
-        if (!$project = $this->projectArgument()) {
+        if (! $project = $this->projectArgument()) {
             $this->error('No project has been configured, either provide a project or set a default');
 
             return;

--- a/app/Commands/SettingsEditCommand.php
+++ b/app/Commands/SettingsEditCommand.php
@@ -39,6 +39,9 @@ PHP documentation for more info: https://www.php.net/manual/en/function.date.php
 
 interval_format: The format string to use for intervals.  Defaults to `%h:%I`.
 See the PHP documentation for more info: https://www.php.net/manual/en/dateinterval.format.php
+
+default_project: The project used when executing command without providing project argument.
+When this value is missing or null a project must be provided with each command that uses project argument.
 HELP;
 
     public function __construct()
@@ -69,7 +72,7 @@ HELP;
     {
         switch ($argumentName) {
             case 'key':
-                return ['timezone', 'date_format', 'time_format', 'interval_format'];
+                return ['timezone', 'date_format', 'time_format', 'interval_format', 'default_project'];
             default:
                 return [];
         }

--- a/app/Commands/StartCommand.php
+++ b/app/Commands/StartCommand.php
@@ -64,7 +64,7 @@ HELP;
             $this->call('stop');
         }
 
-        if (!$project = $this->projectArgument()) {
+        if (! $project = $this->projectArgument()) {
             $this->error('No project has been configured, either provide a project or set a default');
 
             return;

--- a/app/Commands/StartCommand.php
+++ b/app/Commands/StartCommand.php
@@ -18,7 +18,7 @@ class StartCommand extends Command implements CompletionAwareInterface
      * @var string
      */
     protected $signature = 'start
-        {project : The name of the project to start tracking time for}
+        {project? : The name of the project to start tracking time for}
         {--a|at= : The time to start the frame at (Defaults to the current time)}
         {--t|tag=* : The tags to add to the frame}
         {--notes= : The notes to add to the frame}';
@@ -32,7 +32,7 @@ class StartCommand extends Command implements CompletionAwareInterface
      * @var string
      */
     protected $help = <<<'HELP'
-The only required argument is the project name.
+The project is required if no default project exists.
 
 You may specify the start time using the --at option. This is useful if you
 forgot to start time tracking. For example, `hours start blog --at '5 minutes ago'`
@@ -64,7 +64,13 @@ HELP;
             $this->call('stop');
         }
 
-        $frame = Frame::start($this->argument('project'), $this->dateOption('at'))
+        if (!$project = $this->projectArgument()) {
+            $this->error('No project has been configured, either provide a project or set a default');
+
+            return;
+        }
+
+        $frame = Frame::start($project, $this->dateOption('at'))
             ->addTags($this->option('tag'))
             ->addNotes($this->option('notes'));
 

--- a/app/Events/LoadDotHoursFile.php
+++ b/app/Events/LoadDotHoursFile.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Bootstrap;
+
+use Dotenv\Dotenv;
+
+/**
+ * Load .hours file if it exists.
+ */
+class LoadDotHoursFile
+{
+    public function handle(): void
+    {
+        $file = getcwd().DIRECTORY_SEPARATOR.'.hours';
+
+        if (! file_exists($file)) {
+            return;
+        }
+
+        Dotenv::create($file)->load();
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,8 +8,10 @@ use App\Facades\Settings;
 use Carbon\CarbonInterval;
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
+use Dotenv\Dotenv;
 use Illuminate\Console\Command;
 use App\Carbon\CarbonPresentMixin;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\DateFactory;
 use Illuminate\Support\Facades\Date;
@@ -66,5 +68,24 @@ class AppServiceProvider extends ServiceProvider
                 Settings::get('timezone')
             )->utc();
         });
+
+        Command::macro('projectArgument', function () {
+            /** @var Command $this */
+            $project = $this->argument('project');
+
+            if (!$project) {
+                $project = getenv('default_project');
+            }
+
+            if (!$project) {
+                $project = Settings::get('default_project');
+            }
+
+            return $project;
+        });
+
+        if (file_exists($localConfig = getcwd() . DIRECTORY_SEPARATOR . '.hours')) {
+            Dotenv::create(getcwd(), '.hours')->load();
+        }
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use Dotenv\Dotenv;
 use App\Facades\Settings;
 use Carbon\CarbonInterval;
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
-use Dotenv\Dotenv;
 use Illuminate\Console\Command;
 use App\Carbon\CarbonPresentMixin;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\DateFactory;
 use Illuminate\Support\Facades\Date;
@@ -73,18 +72,18 @@ class AppServiceProvider extends ServiceProvider
             /** @var Command $this */
             $project = $this->argument('project');
 
-            if (!$project) {
+            if (! $project) {
                 $project = getenv('default_project');
             }
 
-            if (!$project) {
+            if (! $project) {
                 $project = Settings::get('default_project');
             }
 
             return $project;
         });
 
-        if (file_exists($localConfig = getcwd() . DIRECTORY_SEPARATOR . '.hours')) {
+        if (file_exists($localConfig = getcwd().DIRECTORY_SEPARATOR.'.hours')) {
             Dotenv::create(getcwd(), '.hours')->load();
         }
     }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
-use Dotenv\Dotenv;
 use App\Facades\Settings;
 use Carbon\CarbonInterval;
 use Carbon\CarbonImmutable;
@@ -82,9 +81,5 @@ class AppServiceProvider extends ServiceProvider
 
             return $project;
         });
-
-        if (file_exists($localConfig = getcwd().DIRECTORY_SEPARATOR.'.hours')) {
-            Dotenv::create(getcwd(), '.hours')->load();
-        }
     }
 }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Providers;
 
 use App\Events\ConfigureTimezone;
+use App\Bootstrap\LoadDotHoursFile;
 use App\Bootstrap\InitializeDatabase;
 use Illuminate\Console\Events\ArtisanStarting;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
@@ -19,6 +20,7 @@ class EventServiceProvider extends ServiceProvider
     protected $listen = [
         ArtisanStarting::class => [
             InitializeDatabase::class,
+            LoadDotHoursFile::class,
         ],
     ];
 


### PR DESCRIPTION
First we check the argument provided to the command.
If none is given we check the env setting using `getenv`. Env is read from the `.hours` file
The last check performed is the settings database.

If no project is given we throw an error to the screen informing the user they must provide a project